### PR TITLE
Show log::info on release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ structopt = "0.3"
 ron = "0.8.0"
 serde = { version = "1", features = ["derive"] }
 once_cell = "1.16.0"
-log = { version = "0.4", features = ["max_level_trace", "release_max_level_warn"] }
+log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
 simple_logger = "4.0"
 egui_glfw_gl = { git = "https://github.com/cohaereo/egui_glfw_gl", branch = "master" }

--- a/src/octree/build/mod.rs
+++ b/src/octree/build/mod.rs
@@ -179,7 +179,7 @@ impl Octree {
             }
 
             let nodes_allocated = helpers::get_value_from_atomic_counter(allocated_nodes_counter);
-            log::info!(
+            log::debug!(
                 "{octree_data_type:?} nodes allocated for {}: {}",
                 octree_level + 1,
                 nodes_allocated

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -242,7 +242,7 @@ impl Octree {
             .map(|exponent| 8_usize.pow(exponent))
             .sum::<usize>();
         let max_node_pool_size = number_of_nodes * constants::CHILDREN_PER_NODE as usize;
-        log::info!(
+        log::debug!(
             "Max node pool size based on tree height: {}",
             max_node_pool_size
         );
@@ -253,11 +253,11 @@ impl Octree {
 
         let max_node_pool_size =
             max_node_pool_size.min((max_texture_buffer_size).try_into().unwrap());
-        log::info!(
+        log::debug!(
             "Max node pool size based on memory max: {}",
             max_texture_buffer_size
         );
-        log::info!(
+        log::debug!(
             "Final node pool size based on tree height: {}",
             max_node_pool_size
         );

--- a/src/rendering/common.rs
+++ b/src/rendering/common.rs
@@ -152,5 +152,5 @@ pub unsafe fn log_device_information() {
 
     let mut max_3d_texture_size = 0;
     unsafe { gl::GetIntegerv(gl::MAX_3D_TEXTURE_SIZE, &mut max_3d_texture_size) };
-    log::info!("Maximum 3D texture size (by dimension): {max_3d_texture_size}");
+    log::debug!("Maximum 3D texture size (by dimension): {max_3d_texture_size}");
 }


### PR DESCRIPTION
Previously, running on release mode didn't get us any info on what GPU we were using. Now all `info` logs are shown on release. Some logs have been bumped down to `debug` since they're not that relevant for release.