### PR TITLE
Add Cone Tracing submenu

### DIFF
--- a/assets/shaders/debug/debugConeTracing.glsl
+++ b/assets/shaders/debug/debugConeTracing.glsl
@@ -8,7 +8,7 @@ uniform layout(binding = 2, r32f) imageBuffer sampledColor;
 
 uniform layout(binding = 0, offset = 0) atomic_uint queriedNodesCounter;
 
-uniform float coneAngle;
+uniform float halfConeAngle;
 uniform mat4 projection;
 uniform mat4 view;
 uniform uint voxelDimension;
@@ -64,22 +64,22 @@ void main() {
 
     if (threadIndex == 0) {
         direction = axis;
-        coneTrace(position, direction, coneAngle, maxDistance, false);
+        coneTrace(position, direction, halfConeAngle, maxDistance, false);
     }
 
     if (threadIndex == 1) {
         direction = sinAngle * axis - cosAngle * tangent;
-        coneTrace(position, direction, coneAngle, maxDistance, false);
+        coneTrace(position, direction, halfConeAngle, maxDistance, false);
     }
 
     if (threadIndex == 2) {
         direction = sinAngle * axis + cosAngle * bitangent;
-        coneTrace(position, direction, coneAngle, maxDistance, false);
+        coneTrace(position, direction, halfConeAngle, maxDistance, false);
     }
 
     if (threadIndex == 3) {
         direction = sinAngle * axis - cosAngle * bitangent;
-        coneTrace(position, direction, coneAngle, maxDistance, false);
+        coneTrace(position, direction, halfConeAngle, maxDistance, false);
     }
 }
 
@@ -99,7 +99,7 @@ out vec4 frag_color;
 uniform mat4 projection;
 uniform mat4 view;
 
-uniform float coneAngle;
+uniform float halfConeAngle;
 
 const float PI = 3.14159;
 
@@ -110,7 +110,7 @@ void main() {
 
     frag_color = vec4(1, 1, 0, 1);
 
-    float angleFromPlane = (PI / 2) - coneAngle;
+    float angleFromPlane = (PI / 2) - halfConeAngle;
     drawCone(geom_position[0], direction[0], angleFromPlane, maxDistance[0]);
 }
 

--- a/assets/shaders/debug/debugConeTracing.glsl
+++ b/assets/shaders/debug/debugConeTracing.glsl
@@ -40,19 +40,18 @@ uniform sampler3D brickPoolIrradianceZNeg;
 
 uniform vec3 position;
 uniform vec3 axis;
+uniform float maxDistance;
 
-out vec3 geom_position;
-out float maxDistance;
-out int threadIndex;
-out vec3 direction;
+out VertexData {
+    vec3 position;
+    vec3 direction;
+} Out;
 
 void main() {
-    threadIndex = gl_VertexID;
+    int threadIndex = gl_VertexID;
     vec3 ndc = position * 2.0 - vec3(1);
-    geom_position = ndc;
+    Out.position = ndc;
     gl_Position = projection * view * vec4(ndc, 1);
-
-    maxDistance = 1.0;
 
     float angle = 1.0472;
     float sinAngle = sin(angle);
@@ -63,23 +62,23 @@ void main() {
     vec3 bitangent = cross(axis, tangent);
 
     if (threadIndex == 0) {
-        direction = axis;
-        coneTrace(position, direction, halfConeAngle, maxDistance, false);
+        Out.direction = axis;
+        coneTrace(position, Out.direction, halfConeAngle, maxDistance, false);
     }
 
     if (threadIndex == 1) {
-        direction = sinAngle * axis - cosAngle * tangent;
-        coneTrace(position, direction, halfConeAngle, maxDistance, false);
+        Out.direction = sinAngle * axis - cosAngle * tangent;
+        coneTrace(position, Out.direction, halfConeAngle, maxDistance, false);
     }
 
     if (threadIndex == 2) {
-        direction = sinAngle * axis + cosAngle * bitangent;
-        coneTrace(position, direction, halfConeAngle, maxDistance, false);
+        Out.direction = sinAngle * axis + cosAngle * bitangent;
+        coneTrace(position, Out.direction, halfConeAngle, maxDistance, false);
     }
 
     if (threadIndex == 3) {
-        direction = sinAngle * axis - cosAngle * bitangent;
-        coneTrace(position, direction, halfConeAngle, maxDistance, false);
+        Out.direction = sinAngle * axis - cosAngle * bitangent;
+        coneTrace(position, Out.direction, halfConeAngle, maxDistance, false);
     }
 }
 
@@ -90,15 +89,17 @@ void main() {
 layout (points) in;
 layout (line_strip, max_vertices = 80) out;
 
-in vec3 geom_position[];
-in float maxDistance[];
-in vec3 direction[];
+in VertexData {
+    vec3 position;
+    vec3 direction;
+} In[];
 
 out vec4 frag_color;
 
 uniform mat4 projection;
 uniform mat4 view;
 
+uniform float maxDistance;
 uniform float halfConeAngle;
 
 const float PI = 3.14159;
@@ -106,12 +107,12 @@ const float PI = 3.14159;
 #include "./_drawCone.glsl"
 
 void main() {
-    vec4 startPosition = vec4(geom_position[0], 1);
+    vec4 startPosition = vec4(In[0].position, 1);
 
     frag_color = vec4(1, 1, 0, 1);
 
     float angleFromPlane = (PI / 2) - halfConeAngle;
-    drawCone(geom_position[0], direction[0], angleFromPlane, maxDistance[0]);
+    drawCone(In[0].position, In[0].direction, angleFromPlane, maxDistance);
 }
 
 #shader fragment

--- a/assets/shaders/octree/coneTracing.glsl
+++ b/assets/shaders/octree/coneTracing.glsl
@@ -36,7 +36,7 @@ uniform vec3 lightDirection;
 uniform float shininess;
 uniform mat4 lightViewMatrix;
 uniform mat4 lightProjectionMatrix;
-uniform float coneAngle;
+uniform float halfConeAngle;
 uniform float photonPower;
 uniform bool showIndirectLight;
 uniform vec3 eyePosition;
@@ -211,17 +211,17 @@ float visibilityCalculation(vec4 positionInLightSpace, vec3 normal) {
 vec4 gatherSpecularIndirectLight(vec3 position, vec3 eyeDirection, vec3 normal) {
     vec3 reflectDirection = normalize(reflect(eyeDirection, normalize(normal)));
     //vec3 reflectDirection = normalize(reflect(eyeDirection, vec3(0, 0, -1)));
-    float coneAngle = 0.005;
+    float halfConeAngle = 0.005;
     float maxDistance = 5;
     bool useLighting = true;
 
-    return coneTrace(position, reflectDirection, coneAngle, maxDistance, useLighting);
+    return coneTrace(position, reflectDirection, halfConeAngle, maxDistance, useLighting);
 }
 
 vec4 gatherIndirectLight(vec3 position, vec3 normal, vec3 tangent, bool useLighting) {
     float maxDistance = useLighting ? 1.0 : 0.01;
-    // float coneAngle = 0.261799;
-    //float coneAngle = 0.0001;
+    // float halfConeAngle = 0.261799;
+    //float halfConeAngle = 0.0001;
     vec3 bitangent = cross(normal, tangent);
     vec3 direction;
     vec4 indirectLight = vec4(0);
@@ -234,16 +234,16 @@ vec4 gatherIndirectLight(vec3 position, vec3 normal, vec3 tangent, bool useLight
 
     direction = sinAngle * normal + cosAngle * tangent;
     
-    indirectLight += coneWeight * coneTrace(position, direction, coneAngle, maxDistance, useLighting);
+    indirectLight += coneWeight * coneTrace(position, direction, halfConeAngle, maxDistance, useLighting);
 
     direction = sinAngle * normal - cosAngle * tangent;
-    indirectLight += coneWeight * coneTrace(position, direction, coneAngle, maxDistance, useLighting);
+    indirectLight += coneWeight * coneTrace(position, direction, halfConeAngle, maxDistance, useLighting);
 
     direction = sinAngle * normal + cosAngle * bitangent;
-    indirectLight += coneWeight * coneTrace(position, direction, coneAngle, maxDistance, useLighting);
+    indirectLight += coneWeight * coneTrace(position, direction, halfConeAngle, maxDistance, useLighting);
 
     direction = sinAngle * normal - cosAngle * bitangent;
-    indirectLight += coneWeight * coneTrace(position, direction, coneAngle, maxDistance, useLighting);
+    indirectLight += coneWeight * coneTrace(position, direction, halfConeAngle, maxDistance, useLighting);
 
     indirectLight /= coneWeight * 4;
 

--- a/presets/cone-tracing-menu.ron
+++ b/presets/cone-tracing-menu.ron
@@ -68,7 +68,7 @@
             output: (
                 show_debug_cone: true,
                 move_debug_cone: true,
-                cone_angle_in_degrees: 0.0,
+                cone_angle_in_degrees: 30.0,
                 number_of_cones: 0,
             ),
         ),
@@ -76,9 +76,9 @@
     camera: (
         transform: (
             position: (
-                x: 0.3024207,
-                y: 0.04571815,
-                z: 0.013100186,
+                x: 0.30366376,
+                y: 0.1707336,
+                z: -0.014056869,
             ),
             scale: (
                 x: 1.0,
@@ -86,8 +86,8 @@
                 z: 1.0,
             ),
             rotation: (
-                x: -37.499996,
-                y: 551.4998,
+                x: -24.199987,
+                y: 180.59995,
                 z: 0.0,
             ),
             movement_speed: 1.0,

--- a/presets/cone-tracing-menu.ron
+++ b/presets/cone-tracing-menu.ron
@@ -1,0 +1,100 @@
+(
+    submenus: (
+        all_nodes: (
+            is_showing: false,
+            output: (
+                should_render_octree: false,
+                current_octree_level: 0,
+                octree_nodes_to_visualize: Geometry,
+            ),
+        ),
+        node_search: (
+            is_showing: false,
+            output: (
+                selected_items: [],
+                filter_text: "",
+                should_show_neighbors: false,
+                selected_items_updated: false,
+            ),
+        ),
+        bricks: (
+            is_showing: false,
+            output: (
+                brick_attribute: None,
+                brick_padding: 0.0,
+                bricks_to_show: (
+                    show_z0: false,
+                    show_z1: false,
+                    show_z2: false,
+                ),
+                color_direction: (
+                    x: 1.0,
+                    y: 0.0,
+                    z: 0.0,
+                ),
+                should_show_brick_normals: false,
+            ),
+        ),
+        children: (
+            is_showing: false,
+        ),
+        diagnostics: (),
+        images: (
+            is_showing: false,
+            output: (
+                toggles: (
+                    should_show_color: false,
+                    should_show_direct: false,
+                    should_show_indirect: false,
+                    should_show_indirect_specular: false,
+                    should_show_ambient_occlusion: false,
+                ),
+            ),
+        ),
+        photons: (
+            is_showing: false,
+        ),
+        save_preset: (
+            name: "cone-tracing-menu",
+        ),
+        camera: (
+            is_showing: false,
+            output: (
+                orthographic: false,
+            ),
+        ),
+        cone_tracing: (
+            is_showing: true,
+            output: (
+                show_debug_cone: true,
+                move_debug_cone: true,
+                cone_angle_in_degrees: 0.0,
+                number_of_cones: 0,
+            ),
+        ),
+    ),
+    camera: (
+        transform: (
+            position: (
+                x: 0.3024207,
+                y: 0.04571815,
+                z: 0.013100186,
+            ),
+            scale: (
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+            ),
+            rotation: (
+                x: -37.499996,
+                y: 551.4998,
+                z: 0.0,
+            ),
+            movement_speed: 1.0,
+        ),
+        orthographic: false,
+        movement_speed: 1.0,
+        mouse_sensitivity: 0.1,
+        zoom: 45.0,
+    ),
+)

--- a/src/cone_tracing/debug_cone.rs
+++ b/src/cone_tracing/debug_cone.rs
@@ -21,7 +21,7 @@ use crate::{
 
 pub struct DebugCone {
     pub transform: Transform,
-    pub cone_angle: f32,
+    pub half_cone_angle: f32,
     shader: Shader,
     direction: Vector3<f32>,
     previous_values: HashSet<u32>,
@@ -82,7 +82,7 @@ impl DebugCone {
                 gl::DYNAMIC_READ,
             ),
             nodes_queried_counter: helpers::generate_atomic_counter_buffer1(gl::DYNAMIC_READ),
-            cone_angle: 0.263599,
+            half_cone_angle: 30f32.to_radians(),
             vao,
         }
     }
@@ -207,7 +207,7 @@ impl DebugCone {
             self.direction.z,
         );
         self.shader
-            .set_float(c_str!("coneAngle"), self.cone_angle as f32);
+            .set_float(c_str!("halfConeAngle"), self.half_cone_angle as f32);
 
         // Add more points if we want more debug cones
         gl::DrawArrays(gl::POINTS, 0, 1);

--- a/src/cone_tracing/debug_cone.rs
+++ b/src/cone_tracing/debug_cone.rs
@@ -67,7 +67,7 @@ impl DebugCone {
         Self {
             shader: compile_shaders!("assets/shaders/debug/debugConeTracing.glsl", debug = true),
             transform,
-            direction: vec3(0.0, 0.0, 1.0),
+            direction: vec3(0.0, 1.0, 0.0),
             previous_values: HashSet::new(),
             nodes_queried: helpers::generate_texture_buffer4(
                 1000,

--- a/src/cone_tracing/debug_cone.rs
+++ b/src/cone_tracing/debug_cone.rs
@@ -22,6 +22,8 @@ use crate::{
 pub struct DebugCone {
     pub transform: Transform,
     pub half_cone_angle: f32,
+    pub number_of_cones: u32,
+    pub max_distance: f32,
     shader: Shader,
     direction: Vector3<f32>,
     previous_values: HashSet<u32>,
@@ -67,6 +69,8 @@ impl DebugCone {
         Self {
             shader: compile_shaders!("assets/shaders/debug/debugConeTracing.glsl", debug = true),
             transform,
+            number_of_cones: 1,
+            max_distance: 1.0,
             direction: vec3(0.0, 1.0, 0.0),
             previous_values: HashSet::new(),
             nodes_queried: helpers::generate_texture_buffer4(
@@ -207,10 +211,11 @@ impl DebugCone {
             self.direction.z,
         );
         self.shader
-            .set_float(c_str!("halfConeAngle"), self.half_cone_angle as f32);
+            .set_float(c_str!("halfConeAngle"), self.half_cone_angle);
+        self.shader
+            .set_float(c_str!("maxDistance"), self.max_distance);
 
-        // Add more points if we want more debug cones
-        gl::DrawArrays(gl::POINTS, 0, 1);
+        gl::DrawArrays(gl::POINTS, 0, self.number_of_cones as i32);
 
         let values = helpers::get_values_from_texture_buffer(self.nodes_queried.1, 1000, 42u32);
         let sampled_colors =

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,6 +180,9 @@ fn main() {
     let mut should_show_neighbors = false;
     let mut bricks_to_show = BricksToShow::default();
 
+    let mut should_show_debug_cone = false;
+    let mut should_move_debug_cone = false;
+
     let render_voxel_fragments_shader = RenderVoxelFragmentsShader::init(
         voxel_positions.0,
         voxel_colors.0,
@@ -252,8 +255,6 @@ fn main() {
 
         menu.begin_frame(current_frame);
 
-        dbg!(&camera.orthographic);
-
         // egui render
         if menu.is_showing() {
             menu.show_main_window();
@@ -266,6 +267,7 @@ fn main() {
                 (),
                 PhotonsMenuInput::new(photons.clone()),
                 SavePresetMenuInput::new(&camera, menu.sub_menus.clone()), // TODO: Remove clone
+                (),
                 (),
             ));
             let outputs = menu.get_data();
@@ -293,6 +295,10 @@ fn main() {
 
             // Camera
             camera.orthographic = outputs.8.orthographic;
+
+            // Cone tracing
+            should_show_debug_cone = outputs.9.show_debug_cone;
+            should_move_debug_cone = outputs.9.move_debug_cone;
         }
 
         // This is for debugging
@@ -333,7 +339,8 @@ fn main() {
                 //         &light_framebuffer,
                 //     )
                 // };
-                // &mut light.transform
+                &mut light.transform
+            } else if should_move_debug_cone {
                 &mut debug_cone.transform
             } else {
                 &mut camera.transform
@@ -424,13 +431,14 @@ fn main() {
                 &camera,
             );
 
-            // TODO: Add toggle to menu
-            // debug_cone.run(
-            //     &octree.textures,
-            //     &projection,
-            //     &view,
-            //     &mut selected_debug_nodes,
-            // );
+            if should_show_debug_cone {
+                debug_cone.run(
+                    &octree.textures,
+                    &projection,
+                    &view,
+                    &mut selected_debug_nodes,
+                );
+            }
             static_eye.draw_gizmo(&projection, &view);
             light.draw_gizmo(&projection, &view);
             // quad.render(light_maps.1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,12 +260,12 @@ fn main() {
             menu.show_main_window();
             menu.render((
                 (),
-                NodeSearchMenuInput::new(debug_nodes.clone()),
+                NodeSearchMenuInput::new(&debug_nodes),
                 (),
-                ChildrenMenuInput::new(children.clone()),
+                ChildrenMenuInput::new(&children),
                 DiagnosticsMenuInput::new(fps),
                 (),
-                PhotonsMenuInput::new(photons.clone()),
+                PhotonsMenuInput::new(&photons),
                 SavePresetMenuInput::new(&camera, menu.sub_menus.clone()), // TODO: Remove clone
                 (),
                 (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,7 +278,7 @@ fn main() {
             octree_nodes_to_visualize = outputs.0.octree_nodes_to_visualize.clone();
 
             // Node search
-            selected_debug_nodes = outputs.1.selected_items.clone();
+            selected_debug_nodes = selected_debug_nodes.into_iter().chain(outputs.1.selected_items.clone()).collect();
             node_filter_text = outputs.1.filter_text.clone();
             should_show_neighbors = outputs.1.should_show_neighbors;
             selected_debug_nodes_updated = outputs.1.selected_items_updated;
@@ -300,6 +300,8 @@ fn main() {
             should_show_debug_cone = outputs.9.show_debug_cone;
             should_move_debug_cone = outputs.9.move_debug_cone;
             debug_cone.half_cone_angle = outputs.9.cone_angle_in_degrees.to_radians() / 2.0;
+            debug_cone.number_of_cones = if outputs.9.number_of_cones == 0 { 1 } else { outputs.9.number_of_cones };
+            debug_cone.max_distance = if outputs.9.max_distance == 0.0 { 0.1 } else { outputs.9.max_distance };
         }
 
         // This is for debugging

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,7 +249,6 @@ fn main() {
                 common::handle_show_model(&event, &mut show_model);
                 common::handle_show_voxel_fragment_list(&event, &mut show_voxel_fragment_list);
                 common::handle_light_movement(&event, &mut should_move_light);
-                common::handle_cone_angle(&event, &mut debug_cone.cone_angle);
             }
             menu.handle_event(event);
         }
@@ -300,6 +299,7 @@ fn main() {
             // Cone tracing
             should_show_debug_cone = outputs.9.show_debug_cone;
             should_move_debug_cone = outputs.9.move_debug_cone;
+            debug_cone.half_cone_angle = outputs.9.cone_angle_in_degrees.to_radians() / 2.0;
         }
 
         // This is for debugging
@@ -424,7 +424,7 @@ fn main() {
 
             cone_tracer.run(
                 &light,
-                debug_cone.cone_angle,
+                debug_cone.half_cone_angle,
                 &octree.textures,
                 &geometry_buffers,
                 light_maps,

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,6 +244,7 @@ fn main() {
                     &mut last_x,
                     &mut last_y,
                     &mut camera,
+                    &mut debug_cone,
                 );
                 common::handle_show_model(&event, &mut show_model);
                 common::handle_show_voxel_fragment_list(&event, &mut show_voxel_fragment_list);

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -38,6 +38,7 @@ pub struct SubMenus {
     photons: PhotonsMenu,
     save_preset: SavePresetMenu,
     camera: CameraMenu,
+    cone_tracing: ConeTracingMenu,
 }
 
 type SubMenuInputs<'a> = (
@@ -50,6 +51,7 @@ type SubMenuInputs<'a> = (
     <PhotonsMenu as SubMenu>::InputData<'a>,
     <SavePresetMenu as SubMenu>::InputData<'a>,
     <CameraMenu as SubMenu>::InputData<'a>,
+    <ConeTracingMenu as SubMenu>::InputData<'a>,
 );
 
 type SubMenuOutputs<'a> = (
@@ -62,6 +64,7 @@ type SubMenuOutputs<'a> = (
     &'a <PhotonsMenu as SubMenu>::OutputData,
     &'a <SavePresetMenu as SubMenu>::OutputData,
     &'a <CameraMenu as SubMenu>::OutputData,
+    &'a <ConeTracingMenu as SubMenu>::OutputData,
 );
 
 impl Menu {
@@ -189,6 +192,7 @@ impl Menu {
         self.sub_menus.photons.render(&self.internals, &inputs.6);
         self.sub_menus.save_preset.render(&self.internals, &inputs.7);
         self.sub_menus.camera.render(&self.internals, &inputs.8);
+        self.sub_menus.cone_tracing.render(&self.internals, &inputs.9);
     }
 
     pub fn get_data(&self) -> SubMenuOutputs {
@@ -202,6 +206,7 @@ impl Menu {
             self.sub_menus.photons.get_data(),
             self.sub_menus.save_preset.get_data(),
             self.sub_menus.camera.get_data(),
+            self.sub_menus.cone_tracing.get_data(),
         )
     }
 
@@ -269,6 +274,15 @@ impl Menu {
                 .clicked()
             {
                 self.sub_menus.camera.toggle_showing();
+            }
+            if ui
+                .button(get_button_text(
+                    "Cone Tracing",
+                    self.sub_menus.cone_tracing.is_showing(),
+                ))
+                .clicked()
+            {
+                self.sub_menus.cone_tracing.toggle_showing();
             }
         });
     }

--- a/src/menu/submenus/children.rs
+++ b/src/menu/submenus/children.rs
@@ -9,18 +9,18 @@ pub struct ChildrenMenu {
     is_showing: bool,
 }
 
-pub struct ChildrenMenuInput {
-    children: Vec<u32>,
+pub struct ChildrenMenuInput<'a> {
+    children: &'a [u32],
 }
 
-impl ChildrenMenuInput {
-    pub fn new(children: Vec<u32>) -> Self {
+impl<'a> ChildrenMenuInput<'a> {
+    pub fn new(children: &'a [u32]) -> Self {
         Self { children }
     }
 }
 
 impl<'a> SubMenu for ChildrenMenu {
-    type InputData<'b> = ChildrenMenuInput;
+    type InputData<'b> = ChildrenMenuInput<'b>;
     type OutputData = ();
 
     fn is_showing(&self) -> bool {

--- a/src/menu/submenus/cone_tracing.rs
+++ b/src/menu/submenus/cone_tracing.rs
@@ -20,7 +20,8 @@ pub struct ConeTracingMenuOutput {
     pub show_debug_cone: bool,
     pub move_debug_cone: bool,
     pub cone_angle_in_degrees: f32,
-    number_of_cones: u32,
+    pub number_of_cones: u32,
+    pub max_distance: f32,
 }
 
 impl<'a> SubMenu for ConeTracingMenu {
@@ -57,6 +58,14 @@ impl<'a> SubMenu for ConeTracingMenu {
             ui.label("Cone Angle (degrees):");
             ui.add(
                 egui::Slider::new(&mut self.output.cone_angle_in_degrees, 1.0..=90.0),
+            );
+            ui.label("Number of cones:");
+            ui.add(
+                egui::Slider::new(&mut self.output.number_of_cones, 1..=5),
+            );
+            ui.label("Max distance:");
+            ui.add(
+                egui::Slider::new(&mut self.output.max_distance, 0.1..=1.0),
             );
         });
     }

--- a/src/menu/submenus/cone_tracing.rs
+++ b/src/menu/submenus/cone_tracing.rs
@@ -1,0 +1,59 @@
+use egui_glfw_gl::egui;
+use serde::{Serialize, Deserialize};
+
+use super::super::get_button_text;
+use super::SubMenu;
+use crate::config::CONFIG;
+use crate::menu::MenuInternals;
+use crate::octree::OctreeDataType;
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct ConeTracingMenu {
+    is_showing: bool,
+    output: ConeTracingMenuOutput,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct ConeTracingMenuOutput {
+    pub show_debug_cone: bool,
+    pub move_debug_cone: bool,
+    cone_angle_in_degrees: f32,
+    number_of_cones: u32,
+}
+
+impl<'a> SubMenu for ConeTracingMenu {
+    type InputData<'b> = ();
+    type OutputData = ConeTracingMenuOutput;
+
+    fn is_showing(&self) -> bool {
+        self.is_showing
+    }
+
+    fn toggle_showing(&mut self) {
+        self.is_showing = !self.is_showing;
+    }
+
+    fn get_data(&self) -> &Self::OutputData {
+        &self.output
+    }
+
+    fn render<'b>(&mut self, internals: &MenuInternals, _: &Self::InputData<'b>) {
+        if !self.is_showing() {
+            return;
+        }
+
+        egui::Window::new("Cone Tracing").show(&internals.context, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Debug cone:");
+                if ui.button(get_button_text("Show", self.output.show_debug_cone)).clicked() {
+                    self.output.show_debug_cone = !self.output.show_debug_cone;
+                }
+                if ui.button(get_button_text("Move", self.output.move_debug_cone)).clicked() {
+                    self.output.move_debug_cone = !self.output.move_debug_cone;
+                }
+            });
+        });
+    }
+}

--- a/src/menu/submenus/cone_tracing.rs
+++ b/src/menu/submenus/cone_tracing.rs
@@ -19,7 +19,7 @@ pub struct ConeTracingMenu {
 pub struct ConeTracingMenuOutput {
     pub show_debug_cone: bool,
     pub move_debug_cone: bool,
-    cone_angle_in_degrees: f32,
+    pub cone_angle_in_degrees: f32,
     number_of_cones: u32,
 }
 
@@ -54,6 +54,10 @@ impl<'a> SubMenu for ConeTracingMenu {
                     self.output.move_debug_cone = !self.output.move_debug_cone;
                 }
             });
+            ui.label("Cone Angle (degrees):");
+            ui.add(
+                egui::Slider::new(&mut self.output.cone_angle_in_degrees, 1.0..=90.0),
+            );
         });
     }
 }

--- a/src/menu/submenus/mod.rs
+++ b/src/menu/submenus/mod.rs
@@ -27,6 +27,9 @@ pub use save_preset::{SavePresetMenu, SavePresetMenuInput};
 mod camera;
 pub use camera::{CameraMenu, CameraMenuOutput};
 
+mod cone_tracing;
+pub use cone_tracing::{ConeTracingMenu, ConeTracingMenuOutput};
+
 use serde::{Serialize, Deserialize};
 
 pub trait SubMenu: std::fmt::Debug + Default + for<'a> Deserialize<'a> + Serialize + Clone {

--- a/src/menu/submenus/node_search.rs
+++ b/src/menu/submenus/node_search.rs
@@ -11,12 +11,12 @@ pub struct NodeSearchMenu {
     output: NodeSearchMenuOutput,
 }
 
-pub struct NodeSearchMenuInput {
-    items: Vec<DebugNode>,
+pub struct NodeSearchMenuInput<'a> {
+    items: &'a [DebugNode],
 }
 
-impl NodeSearchMenuInput {
-    pub fn new(items: Vec<DebugNode>) -> Self {
+impl<'a> NodeSearchMenuInput<'a> {
+    pub fn new(items: &'a [DebugNode]) -> Self {
         Self { items }
     }
 }
@@ -31,7 +31,7 @@ pub struct NodeSearchMenuOutput {
 }
 
 impl<'a> SubMenu for NodeSearchMenu {
-    type InputData<'b> = NodeSearchMenuInput;
+    type InputData<'b> = NodeSearchMenuInput<'b>;
     type OutputData = NodeSearchMenuOutput;
 
     fn is_showing(&self) -> bool {

--- a/src/menu/submenus/photons.rs
+++ b/src/menu/submenus/photons.rs
@@ -9,18 +9,18 @@ pub struct PhotonsMenu {
     is_showing: bool,
 }
 
-pub struct PhotonsMenuInput {
-    photons: Vec<u32>,
+pub struct PhotonsMenuInput<'a> {
+    photons: &'a [u32],
 }
 
-impl PhotonsMenuInput {
-    pub fn new(photons: Vec<u32>) -> Self {
+impl<'a> PhotonsMenuInput<'a> {
+    pub fn new(photons: &'a [u32]) -> Self {
         Self { photons }
     }
 }
 
 impl<'a> SubMenu for PhotonsMenu {
-    type InputData<'b> = PhotonsMenuInput;
+    type InputData<'b> = PhotonsMenuInput<'b>;
     type OutputData = ();
 
     fn is_showing(&self) -> bool {

--- a/src/rendering/common.rs
+++ b/src/rendering/common.rs
@@ -7,7 +7,7 @@ use super::{
     camera::Camera,
     transform::{Direction, Transform},
 };
-use crate::{config::CONFIG, handle_increments, helpers, toggle_boolean};
+use crate::{config::CONFIG, handle_increments, helpers, toggle_boolean, cone_tracing::DebugCone};
 
 pub unsafe fn setup_glfw(debug: bool) -> (Glfw, Window, Receiver<(f64, WindowEvent)>) {
     // GLFW: Setup
@@ -68,6 +68,7 @@ pub fn process_events(
     last_x: &mut f32,
     last_y: &mut f32,
     camera: &mut Camera,
+    debug_cone: &mut DebugCone,
 ) {
     match *event {
         glfw::WindowEvent::FramebufferSize(width, height) => {
@@ -90,6 +91,9 @@ pub fn process_events(
             *last_y = y_position;
 
             camera.process_mouse_movement(x_offset, y_offset, true);
+
+            // To be able to move the debug cone with the camera's forward
+            debug_cone.transform.set_rotation_y(camera.transform.rotation_y());
         }
         glfw::WindowEvent::Scroll(_x_offset, y_offset) => {
             camera.process_mouse_scroll(y_offset as f32);

--- a/src/rendering/common.rs
+++ b/src/rendering/common.rs
@@ -7,7 +7,7 @@ use super::{
     camera::Camera,
     transform::{Direction, Transform},
 };
-use crate::{config::CONFIG, handle_increments, helpers, toggle_boolean, cone_tracing::DebugCone};
+use crate::{config::CONFIG, helpers, toggle_boolean, cone_tracing::DebugCone};
 
 pub unsafe fn setup_glfw(debug: bool) -> (Glfw, Window, Receiver<(f64, WindowEvent)>) {
     // GLFW: Setup
@@ -130,16 +130,6 @@ pub fn process_movement_input(
 toggle_boolean!(C, handle_light_movement);
 toggle_boolean!(Num1, handle_show_model);
 toggle_boolean!(Num2, handle_show_voxel_fragment_list);
-handle_increments!(
-    "Cone angle",
-    Up,
-    Down,
-    handle_cone_angle,
-    f32,
-    0.01,
-    0.0,
-    6.0
-);
 
 pub unsafe fn log_device_information() {
     let vendor = unsafe {

--- a/src/rendering/macros.rs
+++ b/src/rendering/macros.rs
@@ -11,33 +11,3 @@ macro_rules! toggle_boolean {
         }
     };
 }
-
-#[macro_export]
-macro_rules! handle_increments {
-    (
-        $name:literal,
-        $up:ident,
-        $down:ident,
-        $fn_name:ident,
-        $type:ty,
-        $increment:literal,
-        $min_value:expr,
-        $max_value:expr
-    ) => {
-        pub fn $fn_name(event: &glfw::WindowEvent, value: &mut $type) {
-            match *event {
-                glfw::WindowEvent::Key(Key::$up, _, Action::Press, _) => {
-                    *value = (*value + $increment).min($max_value);
-                    println!("{} is: {}", $name, *value);
-                }
-                glfw::WindowEvent::Key(Key::$down, _, Action::Press, _) => {
-                    if *value != 0 as $type {
-                        *value = *value - $increment;
-                    }
-                    println!("{} is: {}", $name, *value);
-                }
-                _ => {}
-            }
-        }
-    };
-}


### PR DESCRIPTION
# Description

Added a new menu with cone tracing parameters.

![image](https://github.com/franciscoaguirre/voxel-cone-tracing/assets/4390772/fdd69710-d6ce-41ba-8bbb-8e47103d03e1)

# TODO
- [x] Toggle the debug cone on/off
- [x] Toggle moving the debug cone
- [x] Choose the cone angle
- [x] Choose the number of cones
- [x] Max distance
- [x] Make sure node search and debug cone work properly together
