### PR TITLE
Debugging pixelated cone tracing

### DIFF
--- a/assets/shaders/debug/simpleConeTrace.comp.glsl
+++ b/assets/shaders/debug/simpleConeTrace.comp.glsl
@@ -1,0 +1,36 @@
+//! Simple shader to test `coneTrace`
+//! Meant to be compiled with debug = true
+
+#version 460 core
+
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+uniform layout (binding = 0, r32ui) readonly uimageBuffer nodePool;
+uniform layout (binding = 1, rgba32f) writeonly imageBuffer queriedCoordinates;
+
+uniform layout(binding = 2, r32ui) uimageBuffer nodesQueried;
+uniform layout(binding = 3, r32f) imageBuffer sampledColor;
+
+uniform layout(binding = 0, offset = 0) atomic_uint queriedNodesCounter;
+
+// Uniforms used inside `coneTrace`
+uniform uint voxelDimension;
+uniform uint maxOctreeLevel;
+uniform sampler3D brickPoolColorsX;
+
+// Parameters to `coneTrace`
+uniform vec3 coneOrigin;
+uniform vec3 coneDirection;
+uniform float coneHalfAngle;
+uniform float maxDistance;
+
+#include "assets/shaders/octree/_constants.glsl"
+#include "assets/shaders/octree/_helpers.glsl"
+#include "assets/shaders/octree/_traversalHelpers.glsl"
+#include "assets/shaders/octree/_octreeTraversal.glsl"
+#include "assets/shaders/octree/_brickCoordinates.glsl"
+#include "assets/shaders/octree/_coneTrace.glsl"
+
+void main() {
+    coneTrace(coneOrigin, coneDirection, coneHalfAngle, maxDistance);
+}

--- a/assets/shaders/octree/_coneTrace.glsl
+++ b/assets/shaders/octree/_coneTrace.glsl
@@ -126,11 +126,7 @@ vec4 coneTrace(
         vec3 parentVoxelCoordinates = findVoxel(queryCoordinates, parentNode);
         vec4 childColor;
         vec4 parentColor;
-        if (octreeLevel == maxOctreeLevel) {
-            childColor = getLeafIrradiance(childVoxelCoordinates);
-        } else {
-            childColor = getAnisotropicIrradiance(childVoxelCoordinates, coneDirection);
-        }
+        childColor = getLeafColor(childVoxelCoordinates);
         #if debug
             int aux = 5;
             imageStore(sampledColor, steps * aux + 0 + 5, vec4(childColor.r, 0, 0, 0));
@@ -139,8 +135,7 @@ vec4 coneTrace(
             imageStore(sampledColor, steps * aux + 3 + 5, vec4(childColor.a, 0, 0, 0));
             imageStore(sampledColor, steps * aux + 4 + 5, vec4(octreeLevel, 0, 0, 0));
         #endif
-        parentColor = getAnisotropicIrradiance(parentVoxelCoordinates, coneDirection);
-        // parentColor = getLeafIrradiance(parentVoxelCoordinates);
+        parentColor = getLeafColor(parentVoxelCoordinates);
         vec4 newColor = mix(childColor, parentColor, parentWeight); // Quadrilinear interpolation
         newColor.rgb /= distanceFactor;
 

--- a/assets/shaders/octree/_coneTrace.glsl
+++ b/assets/shaders/octree/_coneTrace.glsl
@@ -64,7 +64,6 @@ vec4 coneTrace(
     vec3 coneDirection, // Normalized
     float coneHalfAngle,
     float maxDistance,
-    bool useLighting
 ) {
     vec4 returnColor = vec4(0);
     uint previousOctreeLevel = maxOctreeLevel;

--- a/assets/shaders/octree/_coneTrace.glsl
+++ b/assets/shaders/octree/_coneTrace.glsl
@@ -76,7 +76,7 @@ vec4 coneTrace(
     int steps = 0;
     
     // Move the cone origin so it doesn't intersect with own voxels
-    vec3 offsetedConeOrigin = coneOrigin + coneDirection * voxelSize * 2;
+    vec3 offsetedConeOrigin = coneOrigin + coneDirection * voxelSize * 0.5;
     while (distanceAlongCone < maxDistance && returnColor.a < 0.97) {
         float coneDiameter = clamp(coneDiameterCoefficient * distanceAlongCone, 0.0009765625, 100.0);
         float lod = calculateLod(coneDiameter);
@@ -160,7 +160,7 @@ vec4 coneTrace(
         // imageStore(sampledColor, 4, vec4(float(octreeLevel), 0, 0, 0));
     #endif
 
-    returnColor.a = min(returnColor.a, 1.0);
+    // returnColor.a = min(returnColor.a, 1.0);
 
     #if debug
         imageStore(sampledColor, 4, vec4(returnColor.a, 0, 0, 0));

--- a/assets/shaders/octree/coneTracing.glsl
+++ b/assets/shaders/octree/coneTracing.glsl
@@ -221,7 +221,7 @@ vec4 gatherSpecularIndirectLight(vec3 position, vec3 eyeDirection, vec3 normal) 
     float maxDistance = 5;
     bool useLighting = true;
 
-    return coneTrace(position, reflectDirection, halfConeAngle, maxDistance, useLighting);
+    return coneTrace(position, reflectDirection, halfConeAngle, maxDistance);
 }
 
 vec4 gatherIndirectLight(vec3 position, vec3 normal, vec3 tangent, bool useLighting) {
@@ -238,16 +238,16 @@ vec4 gatherIndirectLight(vec3 position, vec3 normal, vec3 tangent, bool useLight
 
     direction = sinAngle * normal + cosAngle * tangent;
     
-    indirectLight += coneWeight * coneTrace(position, direction, halfConeAngle, maxDistance, useLighting);
+    indirectLight += coneWeight * coneTrace(position, direction, halfConeAngle, maxDistance);
 
     direction = sinAngle * normal - cosAngle * tangent;
-    indirectLight += coneWeight * coneTrace(position, direction, halfConeAngle, maxDistance, useLighting);
+    indirectLight += coneWeight * coneTrace(position, direction, halfConeAngle, maxDistance);
 
     direction = sinAngle * normal + cosAngle * bitangent;
-    indirectLight += coneWeight * coneTrace(position, direction, halfConeAngle, maxDistance, useLighting);
+    indirectLight += coneWeight * coneTrace(position, direction, halfConeAngle, maxDistance);
 
     direction = sinAngle * normal - cosAngle * bitangent;
-    indirectLight += coneWeight * coneTrace(position, direction, halfConeAngle, maxDistance, useLighting);
+    indirectLight += coneWeight * coneTrace(position, direction, halfConeAngle, maxDistance);
 
     indirectLight /= coneWeight * 4;
 

--- a/assets/shaders/octree/coneTracing.glsl
+++ b/assets/shaders/octree/coneTracing.glsl
@@ -96,7 +96,7 @@ void main() {
     vec3 eyeDirection = normalize(positionRaw - eyePosition);
 
     vec3 normal = texture(gBufferNormals, In.textureCoordinates).xyz;
-    vec3 helper = normal - vec3(0.1, 0, 0); // Random vector
+    vec3 helper = normal - vec3(0.1, 0.1, 0); // Random vector
     vec3 tangent = normalize(helper - dot(normal, helper) * normal);
 
     vec4 color = texture(gBufferColors, In.textureCoordinates);

--- a/assets/shaders/octree/isotropicMipMaps/mipmapCenter.comp.glsl
+++ b/assets/shaders/octree/isotropicMipMaps/mipmapCenter.comp.glsl
@@ -5,7 +5,7 @@
 layout (local_size_x = WORKING_GROUP_SIZE, local_size_y = 1, local_size_z = 1) in;
 
 uniform layout(binding = 0, r32ui) readonly uimageBuffer nodePool;
-uniform layout(binding = 1, rgba32f) image3D brickPoolValues;
+uniform layout(binding = 1, rgba8) image3D brickPoolValues;
 uniform layout(binding = 2, r32ui) readonly uimageBuffer levelStartIndices;
 
 uniform uint octreeLevel;

--- a/assets/shaders/octree/leafBorderTransfer.comp.glsl
+++ b/assets/shaders/octree/leafBorderTransfer.comp.glsl
@@ -15,6 +15,10 @@ uniform uint octreeLevel;
 #include "./_brickCoordinates.glsl"
 #include "./_threadNodeUtil.glsl"
 
+vec4 getFinalValue(vec4 value, vec4 neighborValue) {
+    return 0.5 * (value + neighborValue);
+}
+
 void main() {
     int nodeAddress = getThreadNode();
 
@@ -41,15 +45,7 @@ void main() {
                 vec4 neighborBorderValue = imageLoad(brickPoolValues, neighborBrickAddress + neighborOffset);
                 memoryBarrier();
 
-                vec4 finalValue;
-                // We don't want border nodes to affect the geometry nodes' color
-                if (borderValue == vec4(0)) {
-                    finalValue = neighborBorderValue;
-                } else if (neighborBorderValue == vec4(0)) {
-                    finalValue = borderValue;
-                } else {
-                    finalValue = 0.5 * (borderValue + neighborBorderValue);
-                }
+                vec4 finalValue = getFinalValue(borderValue, neighborBorderValue);
                 imageStore(brickPoolValues, brickAddress + offset, finalValue);
                 imageStore(brickPoolValues, neighborBrickAddress + neighborOffset, finalValue);
             }
@@ -66,15 +62,7 @@ void main() {
                 vec4 neighborBorderValue = imageLoad(brickPoolValues, neighborBrickAddress + neighborOffset);
                 memoryBarrier();
 
-                vec4 finalValue;
-                // We don't want border nodes to affect the geometry nodes' color
-                if (borderValue == vec4(0)) {
-                    finalValue = neighborBorderValue;
-                } else if (neighborBorderValue == vec4(0)) {
-                    finalValue = borderValue;
-                } else {
-                    finalValue = 0.5 * (borderValue + neighborBorderValue);
-                }
+                vec4 finalValue = getFinalValue(borderValue, neighborBorderValue);
                 imageStore(brickPoolValues, brickAddress + offset, finalValue);
                 imageStore(brickPoolValues, neighborBrickAddress + neighborOffset, finalValue);
             }
@@ -91,15 +79,7 @@ void main() {
                 vec4 neighborBorderValue = imageLoad(brickPoolValues, neighborBrickAddress + neighborOffset);
                 memoryBarrier();
 
-                vec4 finalValue;
-                // We don't want border nodes to affect the geometry nodes' color
-                if (borderValue == vec4(0)) {
-                    finalValue = neighborBorderValue;
-                } else if (neighborBorderValue == vec4(0)) {
-                    finalValue = borderValue;
-                } else {
-                    finalValue = 0.5 * (borderValue + neighborBorderValue);
-                }
+                vec4 finalValue = getFinalValue(borderValue, neighborBorderValue);
                 imageStore(brickPoolValues, brickAddress + offset, finalValue);
                 imageStore(brickPoolValues, neighborBrickAddress + neighborOffset, finalValue);
             }

--- a/assets/shaders/voxel_fragment/voxelize.geom.glsl
+++ b/assets/shaders/voxel_fragment/voxelize.geom.glsl
@@ -129,32 +129,32 @@ void main() {
 
     vec3 expandedVertex[3];
     for (int i = 0; i < 3; i++) {
-        vec2 currentEdge = vertex[(i + 1) % 3].xy - vertex[i].xy;
-        vec2 previousEdge = vertex[i].xy - vertex[(i + 2) % 3].xy;
+        // vec2 currentEdge = vertex[(i + 1) % 3].xy - vertex[i].xy;
+        // vec2 previousEdge = vertex[i].xy - vertex[(i + 2) % 3].xy;
 
-        vec2 currentNormal = normalize(vec2(-currentEdge.y, currentEdge.x)) * normalMultiplier;
-        vec2 currentSemiDiagonal = normalToSemiDiagonal(currentNormal);
-        vec2 previousNormal = normalize(vec2(-previousEdge.y, previousEdge.x)) * normalMultiplier;
-        vec2 previousSemiDiagonal = normalToSemiDiagonal(previousNormal);
+        // vec2 currentNormal = normalize(vec2(-currentEdge.y, currentEdge.x)) * normalMultiplier;
+        // vec2 currentSemiDiagonal = normalToSemiDiagonal(currentNormal);
+        // vec2 previousNormal = normalize(vec2(-previousEdge.y, previousEdge.x)) * normalMultiplier;
+        // vec2 previousSemiDiagonal = normalToSemiDiagonal(previousNormal);
 
-        vec2 currentExpanded1 = vertex[i].xy + currentSemiDiagonal * halfPixel;
-        vec2 currentExpanded2 = vertex[(i + 1) % 3].xy + currentSemiDiagonal * halfPixel;
-        vec2 previousExpanded1 = vertex[(i + 2) % 3].xy + previousSemiDiagonal * halfPixel;
-        vec2 previousExpanded2 = vertex[i].xy + previousSemiDiagonal * halfPixel;
+        // vec2 currentExpanded1 = vertex[i].xy + currentSemiDiagonal * halfPixel;
+        // vec2 currentExpanded2 = vertex[(i + 1) % 3].xy + currentSemiDiagonal * halfPixel;
+        // vec2 previousExpanded1 = vertex[(i + 2) % 3].xy + previousSemiDiagonal * halfPixel;
+        // vec2 previousExpanded2 = vertex[i].xy + previousSemiDiagonal * halfPixel;
 
-        vec2 intersection;
-        if (lineIntersection(currentExpanded1, currentExpanded2, previousExpanded1, previousExpanded2, intersection)) {
-            expandedVertex[i].xy = intersection;
-            // Irrelevant which value it is, except for the fact it should be inside clip space (so vertex doesn't get frustumed out)
-            expandedVertex[i].z = 0;
-        } else {
-            // We f***** up
+        // vec2 intersection;
+        // if (lineIntersection(currentExpanded1, currentExpanded2, previousExpanded1, previousExpanded2, intersection)) {
+        //     expandedVertex[i].xy = intersection;
+        //     // Irrelevant which value it is, except for the fact it should be inside clip space (so vertex doesn't get frustumed out)
+        //     expandedVertex[i].z = 0;
+        // } else {
+        //     // We f***** up
             expandedVertex[i] = vertex[i].xyz;
-        }
+        // }
         
-        // Debug values
-        edgeNormal = currentNormal;
-        semiDiagonal = currentSemiDiagonal;
+        // // Debug values
+        // edgeNormal = currentNormal;
+        // semiDiagonal = currentSemiDiagonal;
 
         //gl_Position = vertex[i];
         //Out.position = vec3(vertex[i]);

--- a/assets/shaders/voxel_fragment/voxelize.vert.glsl
+++ b/assets/shaders/voxel_fragment/voxelize.vert.glsl
@@ -14,10 +14,12 @@ out VertexData {
 uniform mat4 model;
 // This is the scene aabb normalization matrix to fit in our voxelization box
 uniform mat4 modelNormalizationMatrix;
+// This is the normal matrix to fix normals
+uniform mat3 normalMatrix;
 
 void main()
 {
     Out.position = (modelNormalizationMatrix * model * vec4(position, 1.0)).xyz;
     Out.textureCoordinates = textureCoordinates;
-    Out.normal = normal;
+    Out.normal = normalize(normalMatrix * normal);
 }

--- a/crates/core/src/cone_tracing/voxel_cone_trace.rs
+++ b/crates/core/src/cone_tracing/voxel_cone_trace.rs
@@ -167,6 +167,8 @@ impl ConeTracer {
             gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_WRAP_S, gl::CLAMP_TO_EDGE as i32);
             gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_WRAP_T, gl::CLAMP_TO_EDGE as i32);
             gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_WRAP_R, gl::CLAMP_TO_EDGE as i32);
+            // gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_MIN_FILTER, _sample_interpolation);
+            // gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_MAG_FILTER, _sample_interpolation);
             gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_MIN_FILTER, gl::NEAREST as i32);
             gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_MAG_FILTER, gl::NEAREST as i32);
             texture_counter += 1;

--- a/crates/core/src/cone_tracing/voxel_cone_trace.rs
+++ b/crates/core/src/cone_tracing/voxel_cone_trace.rs
@@ -160,15 +160,15 @@ impl ConeTracer {
 
         let mut texture_counter = 0;
 
-        for &(texture_name, texture, sample_interpolation) in brick_pool_textures.iter() {
+        for &(texture_name, texture, _sample_interpolation) in brick_pool_textures.iter() {
             gl::ActiveTexture(gl::TEXTURE0 + texture_counter);
             gl::BindTexture(gl::TEXTURE_3D, texture);
             self.shader.set_int(texture_name, texture_counter as i32);
             gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_WRAP_S, gl::CLAMP_TO_EDGE as i32);
             gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_WRAP_T, gl::CLAMP_TO_EDGE as i32);
             gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_WRAP_R, gl::CLAMP_TO_EDGE as i32);
-            gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_MIN_FILTER, sample_interpolation);
-            gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_MAG_FILTER, sample_interpolation);
+            gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_MIN_FILTER, gl::NEAREST as i32);
+            gl::TexParameteri(gl::TEXTURE_3D, gl::TEXTURE_MAG_FILTER, gl::NEAREST as i32);
             texture_counter += 1;
         }
 

--- a/crates/core/src/octree/build/mod.rs
+++ b/crates/core/src/octree/build/mod.rs
@@ -65,49 +65,29 @@ impl Octree {
             BrickPoolValues::Colors,
         );
 
-        self.builder.leaf_border_transfer_pass.run(
-            &self.textures,
-            &self.geometry_data.node_data,
-            &self.border_data.node_data,
-            BrickPoolValues::Colors,
-        );
-
         #[cfg(debug_assertions)]
         self.run_mipmap(BrickPoolValues::Colors);
     }
 
     pub unsafe fn run_mipmap(&self, brick_pool_values: BrickPoolValues) {
-        let all_directions = vec![
-            Direction::new(Axis::X, Sign::Pos),
-            Direction::new(Axis::X, Sign::Neg),
-            Direction::new(Axis::Y, Sign::Pos),
-            Direction::new(Axis::Y, Sign::Neg),
-            Direction::new(Axis::Z, Sign::Pos),
-            Direction::new(Axis::Z, Sign::Neg),
-        ];
-
         let config = Config::instance();
 
         for level in (0..config.octree_levels() - 1).rev() {
-            for direction in all_directions.iter() {
-                self.builder.mipmap_anisotropic_pass.run(
+            self.builder.mipmap_isotropic_pass.run(
+                &self.textures,
+                &self.geometry_data.node_data,
+                level,
+                brick_pool_values,
+            );
+
+            if level > 0 {
+                self.builder.leaf_border_transfer_pass.run(
                     &self.textures,
                     &self.geometry_data.node_data,
+                    &self.border_data.node_data,
+                    BrickPoolValues::Colors,
                     level,
-                    *direction,
-                    brick_pool_values,
                 );
-
-                if level > 0 {
-                    self.builder.anisotropic_border_transfer_pass.run(
-                        &self.textures,
-                        &self.geometry_data.node_data,
-                        &self.border_data.node_data,
-                        level,
-                        brick_pool_values,
-                        *direction,
-                    );
-                }
             }
         }
     }

--- a/crates/core/src/octree/build/mod.rs
+++ b/crates/core/src/octree/build/mod.rs
@@ -65,12 +65,6 @@ impl Octree {
             BrickPoolValues::Colors,
         );
 
-        // self.builder.spread_leaf_bricks_pass.run(
-        //     &self.textures,
-        //     &self.geometry_data.node_data,
-        //     BrickPoolValues::Normals,
-        // );
-
         self.builder.leaf_border_transfer_pass.run(
             &self.textures,
             &self.geometry_data.node_data,
@@ -104,12 +98,6 @@ impl Octree {
                     brick_pool_values,
                 );
 
-                self.builder.mipmap_isotropic_pass.run(
-                    &self.textures,
-                    &self.geometry_data.node_data,
-                    level,
-                );
-
                 if level > 0 {
                     self.builder.anisotropic_border_transfer_pass.run(
                         &self.textures,
@@ -119,12 +107,6 @@ impl Octree {
                         brick_pool_values,
                         *direction,
                     );
-                    // self.builder.border_transfer_pass.run(
-                    //     &self.textures,
-                    //     &self.geometry_data.node_data,
-                    //     level,
-                    //     BrickPoolValues::Normals,
-                    // );
                 }
             }
         }

--- a/crates/core/src/octree/build/mod.rs
+++ b/crates/core/src/octree/build/mod.rs
@@ -55,10 +55,6 @@ impl Octree {
             .process_raw_brick_pool_colors
             .run(&self.geometry_data.node_data, &self.textures);
 
-        self.builder
-            .create_alpha_map
-            .run(&self.textures, &self.geometry_data.node_data);
-
         self.builder.spread_leaf_bricks_pass.run(
             &self.textures,
             &self.geometry_data.node_data,

--- a/crates/core/src/octree/build/stages/leaf_border_transfer.rs
+++ b/crates/core/src/octree/build/stages/leaf_border_transfer.rs
@@ -24,6 +24,7 @@ impl LeafBorderTransferPass {
         geometry_node_data: &NodeData,
         border_node_data: &NodeData,
         brick_pool_values: BrickPoolValues,
+        octree_level: u32, // Not leaf anymore
     ) {
         self.shader.use_program();
 
@@ -39,18 +40,7 @@ impl LeafBorderTransferPass {
                 gl::READ_WRITE,
                 gl::RGBA8,
             ),
-            BrickPoolValues::Normals => helpers::bind_3d_image_texture(
-                1,
-                textures.brick_pool_normals,
-                gl::READ_WRITE,
-                gl::RGBA8,
-            ),
-            BrickPoolValues::Irradiance => helpers::bind_3d_image_texture(
-                1,
-                textures.brick_pool_irradiance[0], // We use +X texture for lower level
-                gl::READ_WRITE,
-                gl::RGBA8,
-            ),
+            _ => panic!("Not now"),
         }
 
         let geometry_nodes_in_level =

--- a/crates/core/src/octree/build/stages/mipmap_isotropic/mipmap_center.rs
+++ b/crates/core/src/octree/build/stages/mipmap_isotropic/mipmap_center.rs
@@ -3,7 +3,7 @@ use engine::prelude::*;
 
 use crate::{
     config::Config,
-    octree::{NodeData, OctreeTextures},
+    octree::{NodeData, OctreeTextures, build::BrickPoolValues},
 };
 
 pub struct MipmapCenterPass {
@@ -19,7 +19,13 @@ impl MipmapCenterPass {
         }
     }
 
-    pub unsafe fn run(&self, textures: &OctreeTextures, node_data: &NodeData, level: u32) {
+    pub unsafe fn run(
+        &self,
+        textures: &OctreeTextures,
+        node_data: &NodeData,
+        level: u32,
+        brick_pool_values: BrickPoolValues,
+    ) {
         self.shader.use_program();
 
         let config = Config::instance();
@@ -28,8 +34,13 @@ impl MipmapCenterPass {
         self.shader
             .set_uint(c_str!("voxelDimension"), config.voxel_dimension());
 
+        let mipmap_texture = match brick_pool_values {
+            BrickPoolValues::Colors => textures.brick_pool_colors[0],
+            _ => panic!("Not supported for now"),
+        };
+
         helpers::bind_image_texture(0, textures.node_pool.0, gl::READ_ONLY, gl::R32UI);
-        helpers::bind_3d_image_texture(1, textures.brick_pool_normals, gl::READ_WRITE, gl::RGBA32F);
+        helpers::bind_3d_image_texture(1, mipmap_texture, gl::READ_WRITE, gl::RGBA8);
         helpers::bind_image_texture(2, node_data.level_start_indices.0, gl::READ_ONLY, gl::R32UI);
 
         let nodes_in_level = node_data.nodes_per_level[level as usize];

--- a/crates/core/src/octree/build/stages/mipmap_isotropic/mipmap_corners.rs
+++ b/crates/core/src/octree/build/stages/mipmap_isotropic/mipmap_corners.rs
@@ -3,7 +3,7 @@ use engine::prelude::*;
 
 use crate::{
     config::Config,
-    octree::{NodeData, OctreeTextures},
+    octree::{NodeData, OctreeTextures, build::BrickPoolValues},
 };
 
 pub struct MipmapCornersPass {
@@ -19,7 +19,13 @@ impl MipmapCornersPass {
         }
     }
 
-    pub unsafe fn run(&self, textures: &OctreeTextures, node_data: &NodeData, level: u32) {
+    pub unsafe fn run(
+        &self,
+        textures: &OctreeTextures,
+        node_data: &NodeData,
+        level: u32,
+        brick_pool_values: BrickPoolValues,
+    ) {
         self.shader.use_program();
 
         let config = Config::instance();
@@ -28,8 +34,13 @@ impl MipmapCornersPass {
         self.shader
             .set_uint(c_str!("voxelDimension"), config.voxel_dimension());
 
+        let mipmap_texture = match brick_pool_values {
+            BrickPoolValues::Colors => textures.brick_pool_colors[0],
+            _ => panic!("Not supported for now"),
+        };
+
         helpers::bind_image_texture(0, textures.node_pool.0, gl::READ_ONLY, gl::R32UI);
-        helpers::bind_3d_image_texture(1, textures.brick_pool_normals, gl::READ_WRITE, gl::RGBA32F);
+        helpers::bind_3d_image_texture(1, mipmap_texture, gl::READ_WRITE, gl::RGBA8);
         helpers::bind_image_texture(2, node_data.level_start_indices.0, gl::READ_ONLY, gl::R32UI);
 
         let nodes_in_level = node_data.nodes_per_level[level as usize];

--- a/crates/core/src/octree/build/stages/mipmap_isotropic/mipmap_faces.rs
+++ b/crates/core/src/octree/build/stages/mipmap_isotropic/mipmap_faces.rs
@@ -3,7 +3,7 @@ use engine::prelude::*;
 
 use crate::{
     config::Config,
-    octree::{NodeData, OctreeTextures},
+    octree::{NodeData, OctreeTextures, build::BrickPoolValues},
 };
 
 pub struct MipmapFacesPass {
@@ -19,7 +19,13 @@ impl MipmapFacesPass {
         }
     }
 
-    pub unsafe fn run(&self, textures: &OctreeTextures, node_data: &NodeData, level: u32) {
+    pub unsafe fn run(
+        &self,
+        textures: &OctreeTextures,
+        node_data: &NodeData,
+        level: u32,
+        brick_pool_values: BrickPoolValues,
+    ) {
         self.shader.use_program();
 
         let config = Config::instance();
@@ -28,8 +34,13 @@ impl MipmapFacesPass {
         self.shader
             .set_uint(c_str!("voxelDimension"), config.voxel_dimension());
 
+        let mipmap_texture = match brick_pool_values {
+            BrickPoolValues::Colors => textures.brick_pool_colors[0],
+            _ => panic!("Not supported for now"),
+        };
+
         helpers::bind_image_texture(0, textures.node_pool.0, gl::READ_ONLY, gl::R32UI);
-        helpers::bind_3d_image_texture(1, textures.brick_pool_normals, gl::READ_WRITE, gl::RGBA32F);
+        helpers::bind_3d_image_texture(1, mipmap_texture, gl::READ_WRITE, gl::RGBA8);
         helpers::bind_image_texture(2, node_data.level_start_indices.0, gl::READ_ONLY, gl::R32UI);
 
         let nodes_in_level = node_data.nodes_per_level[level as usize];

--- a/crates/core/src/octree/build/stages/mipmap_isotropic/mod.rs
+++ b/crates/core/src/octree/build/stages/mipmap_isotropic/mod.rs
@@ -8,7 +8,7 @@ use mipmap_corners::MipmapCornersPass;
 use mipmap_edges::MipmapEdgesPass;
 use mipmap_faces::MipmapFacesPass;
 
-use crate::octree::{NodeData, OctreeTextures};
+use crate::octree::{NodeData, OctreeTextures, build::BrickPoolValues};
 
 pub struct MipmapIsotropicPass {
     center: MipmapCenterPass,
@@ -27,10 +27,16 @@ impl MipmapIsotropicPass {
         }
     }
 
-    pub unsafe fn run(&self, textures: &OctreeTextures, node_data: &NodeData, level: u32) {
-        self.center.run(textures, node_data, level);
-        self.corners.run(textures, node_data, level);
-        self.edges.run(textures, node_data, level);
-        self.faces.run(textures, node_data, level);
+    pub unsafe fn run(
+        &self,
+        textures: &OctreeTextures,
+        node_data: &NodeData,
+        level: u32,
+        brick_pool_values: BrickPoolValues,
+    ) {
+        self.center.run(textures, node_data, level, brick_pool_values);
+        self.corners.run(textures, node_data, level, brick_pool_values);
+        self.edges.run(textures, node_data, level, brick_pool_values);
+        self.faces.run(textures, node_data, level, brick_pool_values);
     }
 }

--- a/crates/core/src/octree/lighting/mod.rs
+++ b/crates/core/src/octree/lighting/mod.rs
@@ -71,13 +71,6 @@ impl Octree {
             BrickPoolValues::Irradiance,
         );
 
-        self.builder.leaf_border_transfer_pass.run(
-            &self.textures,
-            &self.geometry_data.node_data,
-            &self.border_data.node_data,
-            BrickPoolValues::Irradiance,
-        );
-
         self.run_mipmap(BrickPoolValues::Irradiance);
 
         (light_view_map, light_view_map_view, shadow_map)

--- a/crates/core/src/octree/lighting/mod.rs
+++ b/crates/core/src/octree/lighting/mod.rs
@@ -37,42 +37,6 @@ impl Octree {
         let (light_view_map, light_view_map_view, shadow_map) =
             self.create_light_view_map(objects, light, scene_aabb);
 
-        let store_photons_input = StorePhotonsInput {
-            light_view_map,
-            node_pool: self.textures.node_pool,
-            brick_pool_photons: self.textures.brick_pool_photons,
-            is_directional: light.is_directional(),
-        };
-        self.builder
-            .store_photons
-            .run(store_photons_input);
-
-        self.border_transfer(light_view_map);
-
-        let config = Config::instance();
-
-        self.copy_alpha_to_irradiance();
-
-        let photons_to_irradiance_input = PhotonsToIrradianceInput {
-            node_pool: self.textures.node_pool,
-            brick_pool_colors_last_level: self.textures.brick_pool_colors[0],
-            brick_pool_photons: self.textures.brick_pool_photons,
-            brick_pool_irradiance_last_level: self.textures.brick_pool_irradiance[0],
-            light_view_map,
-            is_directional: light.is_directional(),
-        };
-        self.builder
-            .photons_to_irradiance_pass
-            .run(photons_to_irradiance_input);
-
-        self.builder.spread_leaf_bricks_pass.run(
-            &self.textures,
-            &self.geometry_data.node_data,
-            BrickPoolValues::Irradiance,
-        );
-
-        self.run_mipmap(BrickPoolValues::Irradiance);
-
         (light_view_map, light_view_map_view, shadow_map)
     }
 

--- a/crates/core/src/voxelization/voxelize.rs
+++ b/crates/core/src/voxelization/voxelize.rs
@@ -59,38 +59,12 @@ unsafe fn voxelize_scene(
     let model_normalization_matrix = scene_aabb.normalization_matrix();
 
     // Same for every object
-    voxelization_shader.set_mat4(
-        c_str!("modelNormalizationMatrix"),
-        &model_normalization_matrix,
-    );
     voxelization_shader.set_int(c_str!("voxelDimension"), config.voxel_dimension() as i32);
 
     gl::BindBufferBase(gl::ATOMIC_COUNTER_BUFFER, 0, *atomic_counter);
 
     voxelization_shader.set_vec3(c_str!("fallbackColor"), 1.0, 1.0, 1.0);
 
-    let ortho = cgmath::ortho(-1.0, 1.0, -1.0, 1.0, 0.0001, 10_000.0);
-
-    let mut right_camera = Transform::default();
-    right_camera.position = point3(-2.0, 0.0, 0.0);
-    right_camera.set_rotation_y(0.0);
-    let right_view_matrix = ortho * right_camera.get_view_matrix();
-
-    let mut top_camera = Transform::default();
-    top_camera.position = point3(0.0, 2.0, 0.0);
-    top_camera.set_rotation_x(-90.0);
-    top_camera.set_rotation_y(90.0);
-    let top_view_matrix = ortho * top_camera.get_view_matrix();
-
-    let mut far_camera = Transform::default();
-    far_camera.position = point3(0.0, 0.0, 2.0);
-    far_camera.set_rotation_y(-90.0);
-    let far_view_matrix = ortho * far_camera.get_view_matrix();
-
-    voxelization_shader.set_mat4_array(
-        c_str!("axisProjections"),
-        &[&right_view_matrix, &top_view_matrix, &far_view_matrix],
-    );
     gl::Disable(gl::CULL_FACE);
     gl::Disable(gl::DEPTH_TEST);
     // TODO: We should apparently disable depth test and colormask false flase flase

--- a/crates/core/tests/cone_trace.rs
+++ b/crates/core/tests/cone_trace.rs
@@ -1,0 +1,18 @@
+use std::path::PathBuf;
+use std::env;
+
+use engine::prelude::*;
+
+#[test]
+fn cone_trace_coordinates_make_sense() {
+    let (_glfw, _window) = test_utils::init_opengl_context();
+
+    // To go from the crate root to the workspace root
+    let mut path = PathBuf::from(env::current_dir().unwrap());
+    path.pop();
+    path.pop();
+    env::set_current_dir(path).unwrap();
+
+    let shader = compile_compute!("assets/shaders/debug/simpleConeTrace.comp.glsl", debug = true);
+    println!("Successfully compiled shader in test!");
+}

--- a/crates/engine/src/object.rs
+++ b/crates/engine/src/object.rs
@@ -34,6 +34,7 @@ impl Object {
             // Transform's model matrix
             shader.set_mat4(c_str!("model"), &self.transform.get_model_matrix());
             shader.set_mat4(c_str!("modelNormalizationMatrix"), model_normalization_matrix);
+            shader.set_mat3(c_str!("normalMatrix"), &self.transform.get_normal_matrix());
             // Material properties
             self.material().set_uniforms(shader);
         };

--- a/crates/engine/src/shader.rs
+++ b/crates/engine/src/shader.rs
@@ -378,13 +378,13 @@ impl Shader {
     /// ------------------------------------------------------------------------
     unsafe fn check_compile_errors(shader: u32, type_: &str) {
         let mut success = gl::FALSE as GLint;
-        let mut info_log = vec![0u8; 1024];
+        let mut info_log = vec![0u8; 4096];
         if type_ != "PROGRAM" {
             gl::GetShaderiv(shader, gl::COMPILE_STATUS, &mut success);
             if success != gl::TRUE as GLint {
                 gl::GetShaderInfoLog(
                     shader,
-                    1024,
+                    4096,
                     ptr::null_mut(),
                     info_log.as_mut_ptr() as *mut GLchar,
                 );
@@ -400,7 +400,7 @@ impl Shader {
             if success != gl::TRUE as GLint {
                 gl::GetProgramInfoLog(
                     shader,
-                    1024,
+                    4096,
                     ptr::null_mut(),
                     info_log.as_mut_ptr() as *mut GLchar,
                 );
@@ -433,6 +433,9 @@ macro_rules! compile_shaders {
 
 #[macro_export]
 macro_rules! compile_compute {
+    ($compute_path:literal, debug = $value:expr$(,)?) => {
+        Shader::new_compute($compute_path, $value)
+    };
     ($compute_path:expr$(,)?) => {
         Shader::new_compute($compute_path, false)
     };

--- a/crates/engine/src/shader.rs
+++ b/crates/engine/src/shader.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::Read;
 use std::{env, ptr, str};
 
-use cgmath::{vec3, Matrix, Matrix4, Vector3};
+use cgmath::{vec3, Matrix, Matrix4, Vector3, Matrix3};
 use gl::types::*;
 use log::trace;
 
@@ -146,6 +146,14 @@ impl Shader {
         gl::Uniform3f(gl::GetUniformLocation(self.id, name.as_ptr()), x, y, z);
     }
     /// ------------------------------------------------------------------------
+    pub unsafe fn set_mat3(&self, name: &CStr, mat: &Matrix3<f32>) {
+        gl::UniformMatrix3fv(
+            gl::GetUniformLocation(self.id, name.as_ptr()),
+            1,
+            gl::FALSE,
+            mat.as_ptr(),
+        );
+    }
     pub unsafe fn set_mat4(&self, name: &CStr, mat: &Matrix4<f32>) {
         gl::UniformMatrix4fv(
             gl::GetUniformLocation(self.id, name.as_ptr()),

--- a/presets/cornell-box-ao-2.ron
+++ b/presets/cornell-box-ao-2.ron
@@ -1,0 +1,102 @@
+(
+    submenus: (
+        all_nodes: (
+            is_showing: false,
+            output: (
+                should_render_octree: false,
+                current_octree_level: 0,
+                octree_nodes_to_visualize: Geometry,
+            ),
+        ),
+        node_search: (
+            is_showing: false,
+            output: (
+                selected_items: [],
+                filter_text: "",
+                should_show_neighbors: false,
+                selected_items_updated: false,
+            ),
+        ),
+        bricks: (
+            is_showing: false,
+            output: (
+                brick_attribute: None,
+                brick_padding: 0.0,
+                bricks_to_show: (
+                    show_z0: false,
+                    show_z1: false,
+                    show_z2: false,
+                ),
+                color_direction: (
+                    x: 1.0,
+                    y: 0.0,
+                    z: 0.0,
+                ),
+                should_show_brick_normals: false,
+            ),
+        ),
+        children: (
+            is_showing: false,
+        ),
+        diagnostics: (),
+        images: (
+            is_showing: true,
+            output: (
+                toggles: (
+                    should_show_color: false,
+                    should_show_direct: false,
+                    should_show_indirect: false,
+                    should_show_indirect_specular: false,
+                    should_show_ambient_occlusion: true,
+                ),
+            ),
+        ),
+        photons: (
+            is_showing: false,
+        ),
+        save_preset: (
+            name: "cornell-box-ao-2",
+            is_showing: true,
+        ),
+        camera: (
+            is_showing: false,
+            output: (
+                orthographic: false,
+            ),
+        ),
+        cone_tracing: (
+            is_showing: false,
+            output: (
+                show_debug_cone: false,
+                move_debug_cone: false,
+                cone_angle_in_degrees: 0.0,
+                number_of_cones: 0,
+                max_distance: 0.0,
+            ),
+        ),
+    ),
+    camera: (
+        transform: (
+            position: (
+                x: -0.27611324,
+                y: -0.19213514,
+                z: -0.56575704,
+            ),
+            scale: (
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+            ),
+            rotation: (
+                x: -67.29992,
+                y: 114.10007,
+                z: 0.0,
+            ),
+            movement_speed: 1.0,
+        ),
+        orthographic: false,
+        movement_speed: 1.0,
+        mouse_sensitivity: 0.1,
+        zoom: 45.0,
+    ),
+)

--- a/presets/cornell-box-ao-3.ron
+++ b/presets/cornell-box-ao-3.ron
@@ -1,0 +1,102 @@
+(
+    submenus: (
+        all_nodes: (
+            is_showing: false,
+            output: (
+                should_render_octree: false,
+                current_octree_level: 0,
+                octree_nodes_to_visualize: Geometry,
+            ),
+        ),
+        node_search: (
+            is_showing: false,
+            output: (
+                selected_items: [],
+                filter_text: "",
+                should_show_neighbors: false,
+                selected_items_updated: false,
+            ),
+        ),
+        bricks: (
+            is_showing: false,
+            output: (
+                brick_attribute: None,
+                brick_padding: 0.0,
+                bricks_to_show: (
+                    show_z0: false,
+                    show_z1: false,
+                    show_z2: false,
+                ),
+                color_direction: (
+                    x: 1.0,
+                    y: 0.0,
+                    z: 0.0,
+                ),
+                should_show_brick_normals: false,
+            ),
+        ),
+        children: (
+            is_showing: false,
+        ),
+        diagnostics: (),
+        images: (
+            is_showing: true,
+            output: (
+                toggles: (
+                    should_show_color: false,
+                    should_show_direct: false,
+                    should_show_indirect: false,
+                    should_show_indirect_specular: false,
+                    should_show_ambient_occlusion: true,
+                ),
+            ),
+        ),
+        photons: (
+            is_showing: false,
+        ),
+        save_preset: (
+            name: "cornell-box-ao-3",
+            is_showing: true,
+        ),
+        camera: (
+            is_showing: false,
+            output: (
+                orthographic: false,
+            ),
+        ),
+        cone_tracing: (
+            is_showing: false,
+            output: (
+                show_debug_cone: false,
+                move_debug_cone: false,
+                cone_angle_in_degrees: 0.0,
+                number_of_cones: 0,
+                max_distance: 0.0,
+            ),
+        ),
+    ),
+    camera: (
+        transform: (
+            position: (
+                x: -0.346818,
+                y: 0.26277846,
+                z: -0.7428235,
+            ),
+            scale: (
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+            ),
+            rotation: (
+                x: -63.699974,
+                y: 71.8,
+                z: 0.0,
+            ),
+            movement_speed: 1.0,
+        ),
+        orthographic: false,
+        movement_speed: 1.0,
+        mouse_sensitivity: 0.1,
+        zoom: 45.0,
+    ),
+)

--- a/presets/cornell-box-ao-4.ron
+++ b/presets/cornell-box-ao-4.ron
@@ -1,0 +1,102 @@
+(
+    submenus: (
+        all_nodes: (
+            is_showing: false,
+            output: (
+                should_render_octree: false,
+                current_octree_level: 0,
+                octree_nodes_to_visualize: Geometry,
+            ),
+        ),
+        node_search: (
+            is_showing: false,
+            output: (
+                selected_items: [],
+                filter_text: "",
+                should_show_neighbors: false,
+                selected_items_updated: false,
+            ),
+        ),
+        bricks: (
+            is_showing: false,
+            output: (
+                brick_attribute: None,
+                brick_padding: 0.0,
+                bricks_to_show: (
+                    show_z0: false,
+                    show_z1: false,
+                    show_z2: false,
+                ),
+                color_direction: (
+                    x: 1.0,
+                    y: 0.0,
+                    z: 0.0,
+                ),
+                should_show_brick_normals: false,
+            ),
+        ),
+        children: (
+            is_showing: false,
+        ),
+        diagnostics: (),
+        images: (
+            is_showing: true,
+            output: (
+                toggles: (
+                    should_show_color: false,
+                    should_show_direct: false,
+                    should_show_indirect: false,
+                    should_show_indirect_specular: false,
+                    should_show_ambient_occlusion: true,
+                ),
+            ),
+        ),
+        photons: (
+            is_showing: false,
+        ),
+        save_preset: (
+            name: "cornell-box-ao-4",
+            is_showing: true,
+        ),
+        camera: (
+            is_showing: false,
+            output: (
+                orthographic: false,
+            ),
+        ),
+        cone_tracing: (
+            is_showing: false,
+            output: (
+                show_debug_cone: false,
+                move_debug_cone: false,
+                cone_angle_in_degrees: 0.0,
+                number_of_cones: 0,
+                max_distance: 0.0,
+            ),
+        ),
+    ),
+    camera: (
+        transform: (
+            position: (
+                x: -0.15616643,
+                y: -0.12662506,
+                z: -0.096569434,
+            ),
+            scale: (
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+            ),
+            rotation: (
+                x: -52.49996,
+                y: 74.79996,
+                z: 0.0,
+            ),
+            movement_speed: 1.0,
+        ),
+        orthographic: false,
+        movement_speed: 1.0,
+        mouse_sensitivity: 0.1,
+        zoom: 45.0,
+    ),
+)

--- a/presets/cornell-box-ao-border-test.ron
+++ b/presets/cornell-box-ao-border-test.ron
@@ -1,0 +1,102 @@
+(
+    submenus: (
+        all_nodes: (
+            is_showing: false,
+            output: (
+                should_render_octree: false,
+                current_octree_level: 0,
+                octree_nodes_to_visualize: Geometry,
+            ),
+        ),
+        node_search: (
+            is_showing: false,
+            output: (
+                selected_items: [],
+                filter_text: "",
+                should_show_neighbors: false,
+                selected_items_updated: false,
+            ),
+        ),
+        bricks: (
+            is_showing: false,
+            output: (
+                brick_attribute: None,
+                brick_padding: 0.0,
+                bricks_to_show: (
+                    show_z0: false,
+                    show_z1: false,
+                    show_z2: false,
+                ),
+                color_direction: (
+                    x: 1.0,
+                    y: 0.0,
+                    z: 0.0,
+                ),
+                should_show_brick_normals: false,
+            ),
+        ),
+        children: (
+            is_showing: false,
+        ),
+        diagnostics: (),
+        images: (
+            is_showing: true,
+            output: (
+                toggles: (
+                    should_show_color: false,
+                    should_show_direct: false,
+                    should_show_indirect: false,
+                    should_show_indirect_specular: false,
+                    should_show_ambient_occlusion: true,
+                ),
+            ),
+        ),
+        photons: (
+            is_showing: false,
+        ),
+        save_preset: (
+            name: "cornell-box-ao-border-test",
+            is_showing: true,
+        ),
+        camera: (
+            is_showing: false,
+            output: (
+                orthographic: false,
+            ),
+        ),
+        cone_tracing: (
+            is_showing: false,
+            output: (
+                show_debug_cone: false,
+                move_debug_cone: false,
+                cone_angle_in_degrees: 0.0,
+                number_of_cones: 0,
+                max_distance: 0.0,
+            ),
+        ),
+    ),
+    camera: (
+        transform: (
+            position: (
+                x: -0.18731835,
+                y: -0.12537746,
+                z: -0.62476736,
+            ),
+            scale: (
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+            ),
+            rotation: (
+                x: -55.89999,
+                y: 80.59989,
+                z: 0.0,
+            ),
+            movement_speed: 1.0,
+        ),
+        orthographic: false,
+        movement_speed: 1.0,
+        mouse_sensitivity: 0.1,
+        zoom: 45.0,
+    ),
+)

--- a/presets/cornell-box-ao-wall.ron
+++ b/presets/cornell-box-ao-wall.ron
@@ -1,0 +1,102 @@
+(
+    submenus: (
+        all_nodes: (
+            is_showing: false,
+            output: (
+                should_render_octree: false,
+                current_octree_level: 0,
+                octree_nodes_to_visualize: Geometry,
+            ),
+        ),
+        node_search: (
+            is_showing: false,
+            output: (
+                selected_items: [],
+                filter_text: "",
+                should_show_neighbors: false,
+                selected_items_updated: false,
+            ),
+        ),
+        bricks: (
+            is_showing: false,
+            output: (
+                brick_attribute: None,
+                brick_padding: 0.0,
+                bricks_to_show: (
+                    show_z0: false,
+                    show_z1: false,
+                    show_z2: false,
+                ),
+                color_direction: (
+                    x: 1.0,
+                    y: 0.0,
+                    z: 0.0,
+                ),
+                should_show_brick_normals: false,
+            ),
+        ),
+        children: (
+            is_showing: false,
+        ),
+        diagnostics: (),
+        images: (
+            is_showing: true,
+            output: (
+                toggles: (
+                    should_show_color: false,
+                    should_show_direct: false,
+                    should_show_indirect: false,
+                    should_show_indirect_specular: false,
+                    should_show_ambient_occlusion: true,
+                ),
+            ),
+        ),
+        photons: (
+            is_showing: false,
+        ),
+        save_preset: (
+            name: "cornell-box-ao-wall",
+            is_showing: true,
+        ),
+        camera: (
+            is_showing: false,
+            output: (
+                orthographic: false,
+            ),
+        ),
+        cone_tracing: (
+            is_showing: false,
+            output: (
+                show_debug_cone: false,
+                move_debug_cone: false,
+                cone_angle_in_degrees: 0.0,
+                number_of_cones: 0,
+                max_distance: 0.0,
+            ),
+        ),
+    ),
+    camera: (
+        transform: (
+            position: (
+                x: -0.45607588,
+                y: 0.11168102,
+                z: -1.1283388,
+            ),
+            scale: (
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+            ),
+            rotation: (
+                x: -31.500027,
+                y: 87.900246,
+                z: 0.0,
+            ),
+            movement_speed: 1.0,
+        ),
+        orthographic: false,
+        movement_speed: 1.0,
+        mouse_sensitivity: 0.1,
+        zoom: 45.0,
+    ),
+)

--- a/presets/cornell-box-diffuse-2.ron
+++ b/presets/cornell-box-diffuse-2.ron
@@ -1,0 +1,102 @@
+(
+    submenus: (
+        all_nodes: (
+            is_showing: false,
+            output: (
+                should_render_octree: false,
+                current_octree_level: 0,
+                octree_nodes_to_visualize: Geometry,
+            ),
+        ),
+        node_search: (
+            is_showing: false,
+            output: (
+                selected_items: [],
+                filter_text: "",
+                should_show_neighbors: false,
+                selected_items_updated: false,
+            ),
+        ),
+        bricks: (
+            is_showing: false,
+            output: (
+                brick_attribute: None,
+                brick_padding: 0.0,
+                bricks_to_show: (
+                    show_z0: false,
+                    show_z1: false,
+                    show_z2: false,
+                ),
+                color_direction: (
+                    x: 1.0,
+                    y: 0.0,
+                    z: 0.0,
+                ),
+                should_show_brick_normals: false,
+            ),
+        ),
+        children: (
+            is_showing: false,
+        ),
+        diagnostics: (),
+        images: (
+            is_showing: true,
+            output: (
+                toggles: (
+                    should_show_color: true,
+                    should_show_direct: true,
+                    should_show_indirect: true,
+                    should_show_indirect_specular: false,
+                    should_show_ambient_occlusion: false,
+                ),
+            ),
+        ),
+        photons: (
+            is_showing: false,
+        ),
+        save_preset: (
+            name: "cornell-box-diffuse-2",
+            is_showing: true,
+        ),
+        camera: (
+            is_showing: false,
+            output: (
+                orthographic: false,
+            ),
+        ),
+        cone_tracing: (
+            is_showing: false,
+            output: (
+                show_debug_cone: false,
+                move_debug_cone: false,
+                cone_angle_in_degrees: 0.0,
+                number_of_cones: 0,
+                max_distance: 0.0,
+            ),
+        ),
+    ),
+    camera: (
+        transform: (
+            position: (
+                x: -0.053581875,
+                y: -0.12492404,
+                z: -0.6710946,
+            ),
+            scale: (
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
+            ),
+            rotation: (
+                x: -32.900043,
+                y: 7.799937,
+                z: 0.0,
+            ),
+            movement_speed: 1.0,
+        ),
+        orthographic: false,
+        movement_speed: 1.0,
+        mouse_sensitivity: 0.1,
+        zoom: 45.0,
+    ),
+)


### PR DESCRIPTION
Not trying to merge this, just put it up here to view the changes.

I tried a lot of things to try to debug the pixelated cone tracing we've been seeing.
Among them:
- Go back to isotropic mipmap
- Remove special treatment for border nodes in borderTransfer
- Created a unit test for the `coneTrace` function

I'll keep on doing more experiments in this branch, but I already have the following action items from this:
- Removing the special treatment of border nodes from borderTransfer makes the image look better
- Being able to toggle isotropic on and off is useful to know the differences
- We should further unit test coneTrace and all helper functions we deem relevant
  - For this we are most likely going to require some tooling